### PR TITLE
Fix local-up-cluster.sh+test-cmd.sh to have APIServer client

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -115,7 +115,6 @@ sudo "${GO_OUT}/kubelet" \
   --hostname_override="127.0.0.1" \
   --address="127.0.0.1" \
   --api_servers="${API_HOST}:${API_PORT}" \
-  --auth_path="${KUBE_ROOT}/hack/.test-cmd-auth" \
   --port="$KUBELET_PORT" >"${KUBELET_LOG}" 2>&1 &
 KUBELET_PID=$!
 

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -59,7 +59,6 @@ kube::log::status "Starting kubelet"
   --hostname_override="127.0.0.1" \
   --address="127.0.0.1" \
   --api_servers="${API_HOST}:${API_PORT}" \
-  --auth_path="${KUBE_ROOT}/hack/.test-cmd-auth" \
   --port="$KUBELET_PORT" 1>&2 &
 KUBELET_PID=$!
 

--- a/pkg/client/cache/listwatch.go
+++ b/pkg/client/cache/listwatch.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cache
 
 import (
+	"errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
@@ -34,22 +35,30 @@ type ListWatch struct {
 
 // ListWatch knows how to list and watch a set of apiserver resources.
 func (lw *ListWatch) List() (runtime.Object, error) {
-	return lw.Client.
-		Get().
-		Namespace(lw.Namespace).
-		Resource(lw.Resource).
-		SelectorParam("fields", lw.FieldSelector).
-		Do().
-		Get()
+	if lw.Client == nil {
+		return nil, errors.New("No API client: check preceding logs.")
+	} else {
+		return lw.Client.
+			Get().
+			Namespace(lw.Namespace).
+			Resource(lw.Resource).
+			SelectorParam("fields", lw.FieldSelector).
+			Do().
+			Get()
+	}
 }
 
 func (lw *ListWatch) Watch(resourceVersion string) (watch.Interface, error) {
-	return lw.Client.
-		Get().
-		Prefix("watch").
-		Namespace(lw.Namespace).
-		Resource(lw.Resource).
-		SelectorParam("fields", lw.FieldSelector).
-		Param("resourceVersion", resourceVersion).
-		Watch()
+	if lw.Client == nil {
+		return nil, errors.New("No API client: check preceding logs.")
+	} else {
+		return lw.Client.
+			Get().
+			Prefix("watch").
+			Namespace(lw.Namespace).
+			Resource(lw.Resource).
+			SelectorParam("fields", lw.FieldSelector).
+			Param("resourceVersion", resourceVersion).
+			Watch()
+	}
 }

--- a/pkg/standalone/standalone.go
+++ b/pkg/standalone/standalone.go
@@ -59,13 +59,20 @@ func (h *delegateHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 // TODO: replace this with clientcmd
 func GetAPIServerClient(authPath string, apiServerList util.StringList) (*client.Client, error) {
-	authInfo, err := clientauth.LoadFromFile(authPath)
-	if err != nil {
-		return nil, err
+	var authInfo *clientauth.Info
+	var err error
+	if authPath != "" {
+		authInfo, err = clientauth.LoadFromFile(authPath)
+		if err != nil {
+			return nil, err
+		}
 	}
-	clientConfig, err := authInfo.MergeWithConfig(client.Config{})
-	if err != nil {
-		return nil, err
+	clientConfig := client.Config{}
+	if authInfo != nil {
+		clientConfig, err = authInfo.MergeWithConfig(client.Config{})
+		if err != nil {
+			return nil, err
+		}
 	}
 	if len(apiServerList) < 1 {
 		return nil, fmt.Errorf("no api servers specified.")


### PR DESCRIPTION
hack/test-cmd.sh and hack/local-up-cluster.sh panic due when no auth credentials are supplied to connect to the API server:

```
W0119 12:36:25.235155   17155 kubelet.go:124] No API client: stat /home/eric/go/src/github.com/EricMountain-1A/kubernetes/hack/.test-cmd-auth: no such file or directory
...
I0119 12:36:25.235712   17155 util.go:51] Recovered from panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
```

Also, local-up-cluster fails to deploy pods since no client is available in this case.

Both these scripts are intended to use APIServer's localhost port 8080 access which requires no auth checks.

This patch:
- Avoids nil deref in listwatch and provides an error message instead when no client is available.
- --auth_path is no longer mandatory to create a client.Config.
- --auth_path is no longer passed in test-cmd.sh nor local-up-cluster.sh. (It pointed at a non-existing file, hack/.test-cmd-auth.)
